### PR TITLE
feat: add model name for Casambi network device

### DIFF
--- a/custom_components/casambi_bt/__init__.py
+++ b/custom_components/casambi_bt/__init__.py
@@ -44,6 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         identifiers={(DOMAIN, casa_api.casa.networkId)},
         name=casa_api.casa.networkName,
         manufacturer="Casambi",
+        model="network",
         connections={(device_registry.CONNECTION_BLUETOOTH, casa_api.address)}
     )
 


### PR DESCRIPTION
This names the model for the device created for the Casambi network as `network`. 
Would be nice if this value were translatable.

<img width="712" alt="Bildschirm­foto 2022-12-29 um 20 54 01" src="https://user-images.githubusercontent.com/9592452/210005336-51db79db-00c1-413d-a6ec-303eb70ed7f0.png">
<img width="349" alt="Bildschirm­foto 2022-12-29 um 20 54 47" src="https://user-images.githubusercontent.com/9592452/210005338-98302c0e-c69b-4b73-9652-5e04c141820c.png">
