### PR TITLE
feat: add status entity per unit

### DIFF
--- a/custom_components/casambi_bt/__init__.py
+++ b/custom_components/casambi_bt/__init__.py
@@ -10,18 +10,16 @@ import homeassistant.components.bluetooth as bluetooth
 from CasambiBt import Casambi, Group, Scene, Unit, UnitControlType
 from CasambiBt.errors import AuthenticationError, BluetoothError, NetworkNotFoundError
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ADDRESS, CONF_PASSWORD, Platform
+from homeassistant.const import CONF_ADDRESS, CONF_PASSWORD
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
     ConfigEntryError,
     ConfigEntryNotReady,
 )
-from homeassistant.helpers import device_registry
 
-from .const import DOMAIN, IDENTIFIER_NETWORK_ID
+from .const import DOMAIN, PLATFORMS
 
-PLATFORMS = [Platform.LIGHT, Platform.SCENE]
 _LOGGER: Final = logging.getLogger(__name__)
 
 
@@ -39,17 +37,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = casa_api
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    # Regsiter the network device here to avoid code duplication.
-    device_reg = device_registry.async_get(hass)
-    device_reg.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, casa_api.casa.networkId)},
-        name=casa_api.casa.networkName,
-        manufacturer="Casambi",
-        model="Network",
-        connections={(device_registry.CONNECTION_BLUETOOTH, casa_api.address)},
-    )
 
     return True
 

--- a/custom_components/casambi_bt/binary_sensor.py
+++ b/custom_components/casambi_bt/binary_sensor.py
@@ -1,0 +1,72 @@
+"""Binary Sensor implementation for Casambi"""
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass, BinarySensorEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DOMAIN, CasambiApi
+from .entities import CasambiEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+NETWORK_SENSORS: tuple[BinarySensorEntityDescription, ...] = (
+    BinarySensorEntityDescription(
+        key="status",
+        name="Status",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+)
+
+async def async_unload_entry(_hass: HomeAssistant, _entry: ConfigEntry) -> bool:
+    """Support unloading of entry"""
+    return True
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Setting up binary sensor"""
+    _LOGGER.debug("Setting up binary sensor entities. config_entry: %s", config_entry)
+    api: CasambiApi = hass.data[DOMAIN][config_entry.entry_id]
+    binary_sensors = []
+
+    # create network sensors
+    for description in NETWORK_SENSORS:
+        _LOGGER.debug("Adding CasambiBinarySensorEntity for network...")
+        binary_sensors.append(CasambiBinarySensorEntity(api, description))
+
+    if binary_sensors:
+        _LOGGER.debug("Adding binary sensor entities...")
+        async_add_entities(binary_sensors)
+    else:
+        _LOGGER.debug("No binary sensor entities available.")
+
+    return True
+
+
+class CasambiBinarySensorEntity(BinarySensorEntity, CasambiEntity):
+    """Defines a Casambi Binary Sensor Entity."""
+
+    entity_description: BinarySensorEntityDescription
+    _attr_is_on = False
+
+    def __init__(self, api: CasambiApi, description: BinarySensorEntityDescription):
+        super().__init__(api, description)
+        self.entity_description = description
+
+    @property
+    def state(self):
+        """Getter for state."""
+        return STATE_ON if self._api.available else STATE_OFF
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return True

--- a/custom_components/casambi_bt/const.py
+++ b/custom_components/casambi_bt/const.py
@@ -2,7 +2,15 @@
 
 from typing import Final
 
+from homeassistant.const import Platform
+
 DOMAIN: Final = "casambi_bt"
+
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.LIGHT,
+    Platform.SCENE,
+]
 
 CONF_IMPORT_GROUPS: Final = "import_groups"
 

--- a/custom_components/casambi_bt/entities.py
+++ b/custom_components/casambi_bt/entities.py
@@ -1,0 +1,48 @@
+import logging
+
+from typing import Final
+
+from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
+
+from . import DOMAIN, CasambiApi
+
+_LOGGER: Final = logging.getLogger(__name__)
+
+
+class CasambiEntity(Entity):
+    """Defines a Casambi Entity."""
+
+    entity_description: EntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(self, api: CasambiApi, description: EntityDescription):
+        """Initialize Casambi Entity."""
+        self.entity_description = description
+        self._api = api
+        self._attr_name = description.name
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID for this entity."""
+        name = f"{self._api.casa.networkId}"
+        if hasattr(self, "_attr_name"):
+            name += f"-{self._attr_name}"
+        return name.lower()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this Casambi entity."""
+        # return device info for network
+        return DeviceInfo(
+            name=self._api.casa.networkName,
+            manufacturer="Casambi",
+            model="Network",
+            identifiers={(DOMAIN, self._api.casa.networkId)},
+            connections={(device_registry.CONNECTION_BLUETOOTH, self._api.address)}
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._api.available


### PR DESCRIPTION
This adds a `status` entity per ~~unit and~~ network that show the connection status `connected` or `disconnected`. 

<img width="332" alt="Bildschirmfoto 2023-11-10 um 00 10 12" src="https://github.com/lkempf/casambi-bt-hass/assets/9592452/33a79c3a-0dc3-4007-b0b5-282febc5a658">
<img width="334" alt="Bildschirmfoto 2023-11-10 um 00 12 39" src="https://github.com/lkempf/casambi-bt-hass/assets/9592452/51c58203-9122-4989-8042-d8916b787bf7">
