### PR TITLE
fix light entities that do not support temperature changes

### DIFF
--- a/custom_components/casambi_bt/light.py
+++ b/custom_components/casambi_bt/light.py
@@ -129,8 +129,9 @@ class CasambiLightUnit(CasambiLight):
         self._attr_has_entity_name = True
 
         temp_control = unit.unitType.get_control(UnitControlType.TEMPERATURE)
-        self._attr_min_color_temp_kelvin = temp_control.min
-        self._attr_max_color_temp_kelvin = temp_control.max
+        if temp_control is not None:
+            self._attr_min_color_temp_kelvin = temp_control.min
+            self._attr_max_color_temp_kelvin = temp_control.max
 
         super().__init__(api, unit)
 


### PR DESCRIPTION
My lights cannot change the temperature and thus the `get_control(UnitControlType.TEMPERATURE)` call returns None which caused problems while creating the light entities.

To fix this only set the _attr_{min,max}_color_temp_kelvin attributes when it is not None.

Here is the stack trace from hass for reference:
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 293, in _async_setup_platform
    await asyncio.shield(task)
  File "/config/custom_components/casambi_bt/light.py", line 53, in async_setup_entry
    light_entities: list[CasambiLight] = [
  File "/config/custom_components/casambi_bt/light.py", line 54, in <listcomp>
    CasambiLightUnit(casa_api, u) for u in casa_api.get_units(CASA_LIGHT_CTRL_TYPES)
  File "/config/custom_components/casambi_bt/light.py", line 132, in __init__
    self._attr_min_color_temp_kelvin = temp_control.min
AttributeError: 'NoneType' object has no attribute 'min'
```