### PR TITLE
fix: fixes device_info identifier for scenes and groups

### DIFF
--- a/custom_components/casambi_bt/const.py
+++ b/custom_components/casambi_bt/const.py
@@ -6,5 +6,4 @@ DOMAIN: Final = "casambi_bt"
 
 CONF_IMPORT_GROUPS: Final = "import_groups"
 
-IDENTIFIER_NETWORK_ID: Final = "network-id"
 IDENTIFIER_UUID: Final = "uuid"

--- a/custom_components/casambi_bt/light.py
+++ b/custom_components/casambi_bt/light.py
@@ -10,8 +10,8 @@ from typing import Any, Final, cast
 from CasambiBt import Group, Unit, UnitControlType, UnitState, _operation
 
 from .const import (
+    DOMAIN,
     CONF_IMPORT_GROUPS,
-    IDENTIFIER_NETWORK_ID,
 )
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -273,7 +273,7 @@ class CasambiLightGroup(CasambiLight):
     @property
     def device_info(self) -> DeviceInfo:
         return DeviceInfo(
-            identifiers={(IDENTIFIER_NETWORK_ID, self._api.casa.networkId)},
+            identifiers={(DOMAIN, self._api.casa.networkId)},
         )
 
     @property

--- a/custom_components/casambi_bt/scene.py
+++ b/custom_components/casambi_bt/scene.py
@@ -11,7 +11,6 @@ from . import CasambiApi
 
 from .const import (
     DOMAIN,
-    IDENTIFIER_NETWORK_ID,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -52,7 +51,7 @@ class CasambiScene(SceneEntity):
     @property
     def device_info(self) -> DeviceInfo:
         return DeviceInfo(
-            identifiers={(IDENTIFIER_NETWORK_ID, self._api.casa.networkId)},
+            identifiers={(DOMAIN, self._api.casa.networkId)},
         )
 
     async def async_activate(self, **kwargs: Any) -> None:


### PR DESCRIPTION
This makes *scenes* and *groups* to be listed on the *network* device instead of an unknown device. 

Addition to https://github.com/lkempf/casambi-bt-hass/commit/9038c20bff84da13480263f1f421a012a203efbc