### PR TITLE
fix: mark scene as unavailable when network goes offline

### DIFF
--- a/custom_components/casambi_bt/binary_sensor.py
+++ b/custom_components/casambi_bt/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DOMAIN, CasambiApi
-from .entities import CasambiEntity
+from .entities import CasambiNetworkEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ async def async_setup_entry(
         _LOGGER.debug("No binary sensor entities available.")
 
 
-class CasambiBinarySensorEntity(BinarySensorEntity, CasambiEntity):
+class CasambiBinarySensorEntity(BinarySensorEntity, CasambiNetworkEntity):
     """Defines a Casambi Binary Sensor Entity."""
 
     entity_description: BinarySensorEntityDescription
@@ -60,7 +60,7 @@ class CasambiBinarySensorEntity(BinarySensorEntity, CasambiEntity):
 
     def __init__(self, api: CasambiApi, description: BinarySensorEntityDescription):
         """Initialize a Casambi Binary Sensor Entity."""
-        super().__init__(api, description)
+        super().__init__(api=api, description=description)
         self.entity_description = description
 
     @property

--- a/custom_components/casambi_bt/entities.py
+++ b/custom_components/casambi_bt/entities.py
@@ -1,0 +1,52 @@
+import logging
+
+from typing import Final
+
+from CasambiBt import Scene as CasambiScene
+
+from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
+
+from . import DOMAIN, CasambiApi
+
+_LOGGER: Final = logging.getLogger(__name__)
+
+
+class CasambiEntity(Entity):
+    """Defines a Casambi Entity."""
+
+    entity_description: EntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(self, api: CasambiApi, obj: CasambiScene, description: EntityDescription):
+        """Initialize Casambi Entity."""
+        self.entity_description = description
+        self._attr_name = description.name
+        self._api = api
+        self._obj = obj
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID for this entity."""
+        name = f"{self._api.casa.networkId}"
+        if self._obj is not None and isinstance(self._obj, CasambiScene):
+            name += "-scene"
+        name += f"-{self.description.key}"
+        return name.lower()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this Casambi entity."""
+        # return device info for network
+        return DeviceInfo(
+            name=self._api.casa.networkName,
+            manufacturer="Casambi",
+            model="Network",
+            identifiers={(DOMAIN, self._api.casa.networkId)},
+            connections={(device_registry.CONNECTION_BLUETOOTH, self._api.address)}
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._api.available

--- a/custom_components/casambi_bt/entities.py
+++ b/custom_components/casambi_bt/entities.py
@@ -1,7 +1,7 @@
 """Common functionality for entities."""
 
 import logging
-from typing import Final
+from typing import Any, Final
 
 from CasambiBt import Scene as CasambiScene
 
@@ -13,13 +13,13 @@ from . import DOMAIN, CasambiApi
 _LOGGER: Final = logging.getLogger(__name__)
 
 
-class CasambiEntity(Entity):
-    """Defines a Casambi Entity."""
+class CasambiNetworkEntity(Entity):
+    """Defines a Casambi Entity belonging to the network device."""
 
     entity_description: EntityDescription
     _attr_has_entity_name = True
 
-    def __init__(self, api: CasambiApi, obj: CasambiScene, description: EntityDescription):
+    def __init__(self, api: CasambiApi, description: EntityDescription, obj: Any = None):
         """Initialize Casambi Entity."""
         self.entity_description = description
         self._api = api

--- a/custom_components/casambi_bt/entities.py
+++ b/custom_components/casambi_bt/entities.py
@@ -21,7 +21,6 @@ class CasambiEntity(Entity):
     def __init__(self, api: CasambiApi, obj: CasambiScene, description: EntityDescription):
         """Initialize Casambi Entity."""
         self.entity_description = description
-        self._attr_name = description.name
         self._api = api
         self._obj = obj
 
@@ -31,7 +30,7 @@ class CasambiEntity(Entity):
         name = f"{self._api.casa.networkId}"
         if self._obj is not None and isinstance(self._obj, CasambiScene):
             name += "-scene"
-        name += f"-{self.description.key}"
+        name += f"-{self.entity_description.key}"
         return name.lower()
 
     @property

--- a/custom_components/casambi_bt/entities.py
+++ b/custom_components/casambi_bt/entities.py
@@ -1,4 +1,5 @@
 """Common functionality for entities."""
+
 import logging
 from typing import Final
 

--- a/custom_components/casambi_bt/scene.py
+++ b/custom_components/casambi_bt/scene.py
@@ -36,11 +36,11 @@ async def async_setup_entry(
 
 class CasambiScene(SceneEntity, CasambiEntity):
     """Defines a Casambi scene entity."""
-    
+
     _attr_should_poll = True
 
     def __init__(self, api: CasambiApi, scene: Scene) -> None:
-        """Initialize a Casambi scene entity."""      
+        """Initialize a Casambi scene entity."""
         super().__init__(api, scene, EntityDescription(key=scene.sceneId, name=scene.name))
 
 

--- a/custom_components/casambi_bt/scene.py
+++ b/custom_components/casambi_bt/scene.py
@@ -16,7 +16,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import CasambiApi
 from .const import DOMAIN
-
 from .entities import CasambiEntity
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/casambi_bt/scene.py
+++ b/custom_components/casambi_bt/scene.py
@@ -37,6 +37,9 @@ async def async_setup_entry(
 
 
 class CasambiScene(SceneEntity, CasambiEntity):
+
+    _attr_should_poll = True
+
     def __init__(self, api: CasambiApi, scene: Scene) -> None:
         super().__init__(api, scene, EntityDescription(key=scene.sceneId, name=scene.name))
 

--- a/custom_components/casambi_bt/scene.py
+++ b/custom_components/casambi_bt/scene.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import CasambiApi
 from .const import DOMAIN
-from .entities import CasambiEntity
+from .entities import CasambiNetworkEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,14 +33,14 @@ async def async_setup_entry(
     async_add_entities(scenes)
 
 
-class CasambiScene(SceneEntity, CasambiEntity):
+class CasambiScene(SceneEntity, CasambiNetworkEntity):
     """Defines a Casambi scene entity."""
 
     _attr_should_poll = True
 
     def __init__(self, api: CasambiApi, scene: Scene) -> None:
         """Initialize a Casambi scene entity."""
-        super().__init__(api, scene, EntityDescription(key=scene.sceneId, name=scene.name))
+        super().__init__(api=api, description=EntityDescription(key=scene.sceneId, name=scene.name), obj=scene)
 
 
     async def async_activate(self, **kwargs: Any) -> None:

--- a/custom_components/casambi_bt/scene.py
+++ b/custom_components/casambi_bt/scene.py
@@ -14,11 +14,13 @@ from .const import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.components.scene import Scene as SceneEntity
+
+from .entities import CasambiEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,24 +36,9 @@ async def async_setup_entry(
     async_add_entities(scenes)
 
 
-class CasambiScene(SceneEntity):
+class CasambiScene(SceneEntity, CasambiEntity):
     def __init__(self, api: CasambiApi, scene: Scene) -> None:
-        self._api = api
-        self.scene = scene
-
-    @property
-    def name(self) -> str:
-        return self.scene.name
-
-    @property
-    def unique_id(self) -> str:
-        return f"{self._api.casa.networkId}-scene-{self.scene.sceneId}"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._api.casa.networkId)},
-        )
+        super().__init__(api, scene, EntityDescription(key=scene.sceneId, name=scene.name))
 
     async def async_activate(self, **kwargs: Any) -> None:
         _LOGGER.info(f"Switching to scene {self.name}")


### PR DESCRIPTION
This marks a scene as unavailable when the API is disconnected. 

Needs to be aligned with #14 