### PR TITLE
fix: handle invalid network adress

### DIFF
--- a/custom_components/casambi_bt/translations/en.json
+++ b/custom_components/casambi_bt/translations/en.json
@@ -10,7 +10,7 @@
         },
         "error": {
             "cannot_connect": "Failed to connect",
-            "invalid_address": "The bluetooth MAC address of the netowrk is invalid.",
+            "invalid_address": "The bluetooth MAC address of the network is invalid.",
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
         },

--- a/custom_components/casambi_bt/translations/en.json
+++ b/custom_components/casambi_bt/translations/en.json
@@ -10,6 +10,7 @@
         },
         "error": {
             "cannot_connect": "Failed to connect",
+            "invalid_address": "The bluetooth MAC address of the netowrk is invalid.",
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
         },

--- a/custom_components/casambi_bt/translations/nl.json
+++ b/custom_components/casambi_bt/translations/nl.json
@@ -10,6 +10,7 @@
         },
         "error": {
             "cannot_connect": "Kon geen verbinding maken",
+            "invalid_address": "The bluetooth MAC address of the netowrk is invalid.",
             "invalid_auth": "Foutieve authenticatie",
             "unknown": "Onverwachte fout"
         },
@@ -17,7 +18,6 @@
             "user": {
                 "data": {
                     "address": "Adres (Casambi NetworkID)",
-                    "invalid_address": "The bluetooth MAC address of the netowrk is invalid.",
                     "import_groups": "Importeer groupen?",
                     "password": "Wachtwoord"
                 },

--- a/custom_components/casambi_bt/translations/nl.json
+++ b/custom_components/casambi_bt/translations/nl.json
@@ -17,6 +17,7 @@
             "user": {
                 "data": {
                     "address": "Adres (Casambi NetworkID)",
+                    "invalid_address": "The bluetooth MAC address of the netowrk is invalid.",
                     "import_groups": "Importeer groupen?",
                     "password": "Wachtwoord"
                 },

--- a/custom_components/casambi_bt/translations/nl.json
+++ b/custom_components/casambi_bt/translations/nl.json
@@ -10,7 +10,7 @@
         },
         "error": {
             "cannot_connect": "Kon geen verbinding maken",
-            "invalid_address": "The bluetooth MAC address of the netowrk is invalid.",
+            "invalid_address": "The bluetooth MAC address of the network is invalid.",
             "invalid_auth": "Foutieve authenticatie",
             "unknown": "Onverwachte fout"
         },


### PR DESCRIPTION
This handles the network bluetooth MAC address without `:` as it's displayed in the Casambi App.
It also stops the validation if the address is invalid (has to be 17 characters).

fixes #4 