### PR TITLE
Remove unused import of IDENTIFIER_NETWORK_ID

### DIFF
--- a/custom_components/casambi_bt/__init__.py
+++ b/custom_components/casambi_bt/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.exceptions import (
 )
 from homeassistant.helpers import device_registry
 
-from .const import DOMAIN, IDENTIFIER_NETWORK_ID
+from .const import DOMAIN
 
 PLATFORMS = [Platform.LIGHT, Platform.SCENE]
 _LOGGER: Final = logging.getLogger(__name__)


### PR DESCRIPTION
This fixes #54 

Leftover from https://github.com/lkempf/casambi-bt-hass/pull/43