### PR TITLE
Fix Activating Casambi Scenes from Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,10 @@ Place the `casambi_bt` folder in the `custom_components` folder.
 Add this repository as custom repository in the HACS store (HACS -> integrations -> custom repositories):
 
 1. Setup HACS https://hacs.xyz/
-2. Go to integrations section.
-3. Click on the 3 dots in the top right corner.
-4. Select "Custom repositories"
-5. Add the URL to the repository.
-6. Select the integration category.
-7. Click the "ADD" button.
-8. Search for the Casambi **Bluetooth** integration and install it.
+2. Select HACS from the left sidebar
+3. Search for `Casambi **Bluetooth**` in the searchbar at the top and select it
+4. Click the Download button at the bottom right
+5. Restart Home Assistant
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this repository as custom repository in the HACS store (HACS -> integrations
 
 1. Setup HACS https://hacs.xyz/
 2. Select HACS from the left sidebar
-3. Search for `Casambi **Bluetooth**` in the searchbar at the top and select it
+3. Search for `Casambi **Bluetooth**` in the searchbar at the top and select it. If you can't find it you might have to add this repository as a custom repository.
 4. Click the Download button at the bottom right
 5. Restart Home Assistant
 

--- a/custom_components/casambi_bt/scene.py
+++ b/custom_components/casambi_bt/scene.py
@@ -47,4 +47,4 @@ class CasambiScene(SceneEntity, CasambiNetworkEntity):
         """Activate a scene."""
         _LOGGER.info("Switching to scene %s", self.name)
         brightness = kwargs.get(ATTR_BRIGHTNESS, 0xFF)
-        await self._api.casa.switchToScene(self.scene, brightness)
+        await self._api.casa.switchToScene(self._obj, brightness)


### PR DESCRIPTION
When activating a Scene, I got an error from here, because self.scene isn't set:
https://github.com/lkempf/casambi-bt-hass/blob/main/custom_components/casambi_bt/scene.py#L50
This fixes that error.

I've also updated the docs for HACS setup – the custom repository route doesn't seem to be necessary any longer.