### PR TITLE
Fix "None" being added to light entity names

### DIFF
--- a/custom_components/casambi_bt/light.py
+++ b/custom_components/casambi_bt/light.py
@@ -137,7 +137,7 @@ class CasambiLightUnit(CasambiLight, CasambiUnitEntity):
             self._attr_min_color_temp_kelvin = temp_control.min
             self._attr_max_color_temp_kelvin = temp_control.max
 
-        desc = TypedEntityDescription(key=unit.uuid, entity_type="light")
+        desc = TypedEntityDescription(key=unit.uuid, name=None, entity_type="light")
 
         self._obj: Unit
         super().__init__(api, desc, unit)


### PR DESCRIPTION
## Proposed change

Fix "None" being added to the end of names of light entities.

Example:

<img width="408" alt="Screenshot 2025-02-15 at 14 52 35" src="https://github.com/user-attachments/assets/514b857b-e11f-4a17-a919-13b4f9311dd9" />

## Details

The fix simply adds `name=None` to the `TypedEntityDescription` of the light entities.

It tells Home Assistant, that this entity is the main entity of the device and it should therefore have the device's name without any postfix.

It's needed because without it, the name is considered _undefined_ which results in the entity getting the "None" name.