### PR TITLE
Fixes to the vertical distribution entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ Supported control types:
 - Rgb
 - OnOff
 - Temperature (Only for units since there are some open problems for groups.)
+- Vertical
 
 Not supported yet:
 - Switches
 - Sensors
-- Additional control types (e.g. temperature, vertical, ...)
+- Additional control types (e.g. temperature, ...)
 - Networks with classic firmware
 
 ## Reporting issues

--- a/custom_components/casambi_bt/number.py
+++ b/custom_components/casambi_bt/number.py
@@ -8,7 +8,11 @@ from typing import cast
 
 from CasambiBt import Group, Unit, UnitControlType
 
-from homeassistant.components.number import NumberDeviceClass, NumberEntity
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -52,6 +56,10 @@ async def async_setup_entry(
     async_add_entities(light_entities + group_entities)
 
 
+class TypedNumberEntityDescription(TypedEntityDescription, NumberEntityDescription):
+    """Describes a CasambiVerticalNumberUnit."""
+
+
 class CasambiVerticalNumber(CasambiEntity, NumberEntity, metaclass=ABCMeta):
     """Defines a Casambi vertical entity base class.
 
@@ -59,7 +67,9 @@ class CasambiVerticalNumber(CasambiEntity, NumberEntity, metaclass=ABCMeta):
     """
 
     def __init__(
-        self, api: CasambiApi, description: TypedEntityDescription, obj: Group | Unit
+        self, api: CasambiApi,
+        description: TypedNumberEntityDescription,
+        obj: Group | Unit,
     ) -> None:
         """Initialize a Casambi vertical entity base class."""
 
@@ -81,7 +91,7 @@ class CasambiVerticalNumberUnit(CasambiVerticalNumber, CasambiUnitEntity):
     def __init__(self, api: CasambiApi, unit: Unit) -> None:
         """Initialize a Casambi vertical entity."""
 
-        desc = TypedEntityDescription(key=unit.uuid, entity_type="vertical")
+        desc = TypedNumberEntityDescription(key=unit.uuid, entity_type="vertical")
 
         self._obj: Unit
         super().__init__(api, desc, unit)
@@ -101,7 +111,7 @@ class CasambiVerticalNumberGroup(CasambiVerticalNumber, CasambiNetworkEntity):
     def __init__(self, api: CasambiApi, group: Group) -> None:
         """Initialize a Casambi vertical group entity."""
 
-        desc = TypedEntityDescription(
+        desc = TypedNumberEntityDescription(
             key=str(group.groudId), name=group.name, entity_type="vertical"
         )
         super().__init__(api, desc, group)

--- a/custom_components/casambi_bt/number.py
+++ b/custom_components/casambi_bt/number.py
@@ -21,7 +21,7 @@ from . import CasambiApi
 from .const import CONF_IMPORT_GROUPS, DOMAIN
 from .entities import (
     CasambiEntity,
-    CasambiNetworkEntity,
+    CasambiNetworkGroup,
     CasambiUnitEntity,
     TypedEntityDescription,
 )
@@ -105,7 +105,7 @@ class CasambiVerticalNumberUnit(CasambiVerticalNumber, CasambiUnitEntity):
         return None
 
 
-class CasambiVerticalNumberGroup(CasambiVerticalNumber, CasambiNetworkEntity):
+class CasambiVerticalNumberGroup(CasambiVerticalNumber, CasambiNetworkGroup):
     """Defines a Casambi vertical entity group."""
 
     def __init__(self, api: CasambiApi, group: Group) -> None:
@@ -114,4 +114,18 @@ class CasambiVerticalNumberGroup(CasambiVerticalNumber, CasambiNetworkEntity):
         desc = TypedNumberEntityDescription(
             key=str(group.groudId), name=group.name, entity_type="vertical"
         )
+
+        self._obj: Group
         super().__init__(api, desc, group)
+
+    @property
+    def native_value(self) -> float | None:
+        """Get the average vertical value of the group."""
+        group = cast(Group, self._obj)
+        values = [
+            float(unit.state.vertical) for unit in group.units
+            if unit.state is not None and unit.state.vertical is not None
+        ]
+        if values:
+            return sum(values) / len(values)
+        return None


### PR DESCRIPTION
## Proposed change

Fix issues with the vertical distribution number entities.

1. Crash at startup that prevents the entities from being created in Home Assistant
   Reported here: https://github.com/lkempf/casambi-bt-hass/issues/101
2. Vertical distribution entities for groups are always unavailable with unknown value
3. Outdated README

## What's changed

The crash is fixed by deriving the entity description from `NumberEntityDescription` instead of the generic `EntityDescription`. The generic one is missing some properties expected by the `NumberEntity`.

Group availability is fixed by deriving `CasambiVerticalNumberGroup` from `CasambiNetworkGroup` instead of `CasambiNetworkEntity`. The former is a subclass with the required `available` property.

The group value being unknown is fixed by implementing the `native_value` property for `CasambiVerticalNumberGroup`. It averages the vertical distribution from all units in the group (that support it).
