### PR TITLE
Fix: Adjust colorsource setter to enum refactor

### DIFF
--- a/custom_components/casambi_bt/light.py
+++ b/custom_components/casambi_bt/light.py
@@ -7,7 +7,7 @@ from copy import copy
 import logging
 from typing import Any, Final, cast
 
-from CasambiBt import Group, Unit, UnitControlType, UnitState, _operation
+from CasambiBt import ColorSource, Group, Unit, UnitControlType, UnitState, _operation
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -207,19 +207,19 @@ class CasambiLightUnit(CasambiLight, CasambiUnitEntity):
         if ATTR_RGBW_COLOR in kwargs:
             state.rgb = kwargs[ATTR_RGBW_COLOR][:3]
             state.white = kwargs[ATTR_RGBW_COLOR][3]
-            state.colorsource = 1
+            state.colorsource = ColorSource.RGB
             set_state = True
         if ATTR_RGB_COLOR in kwargs:
             state.rgb = kwargs[ATTR_RGB_COLOR]
-            state.colorsource = 1
+            state.colorsource = ColorSource.RGB
             set_state = True
         if ATTR_COLOR_TEMP_KELVIN in kwargs:
             state.temperature = kwargs[ATTR_COLOR_TEMP_KELVIN]
-            state.colorsource = 0
+            state.colorsource = ColorSource.TEMPERATURE
             set_state = True
         if ATTR_XY_COLOR in kwargs:
             state.xy = kwargs[ATTR_XY_COLOR]
-            state.colorsource = 2
+            state.colorsource = ColorSource.XY
             set_state = True
 
         if set_state:


### PR DESCRIPTION
Currently XY color mode appears to be broken. The colorsource state is an enum in casambi-bt and thus enum values have to be set.

While implementing #84 I missed the final refactoring done in https://github.com/lkempf/casambi-bt/pull/25/commits/a655a0629136843eb62eb1eb0a5d5ce3f563a57d . 
This was somehow also not noticed by me when testing the final PR. Maybe I still had my version of casambi-bt pinned?