### PR TITLE
feat: Add switch button event support for automations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,30 @@ Supported control types:
 - Vertical
 
 Not supported yet:
-- Switches
+- Switches (as entities) - **NEW**: Physical switch button press, hold, and release events
 - Sensors
 - Additional control types (e.g. temperature, ...)
 - Networks with classic firmware
+
+### Switch Button Events
+
+Physical switches now fire events for automations:
+- Button press, hold, and release detection
+- ~500ms press-to-hold delay
+- Support for short/long press actions
+
+Events are fired as `casambi_bt_switch_event` and can be used in automations.
+
+[**→ Detailed Switch Event Documentation**](docs/SWITCH_EVENTS.md)
+
+### Automation Blueprints
+
+The integration includes ready-to-use blueprints for common switch patterns:
+- **Toggle and Dim** - All-in-one light control (short press = toggle, hold = dim)
+- **Button Actions** - Versatile automation for any button event
+- **Cover Control** - Smart blind/cover control
+
+[**→ Blueprint Documentation**](docs/BLUEPRINTS.md)
 
 ## Reporting issues
 

--- a/blueprints/automation/casambi_bt/button_cover_control.yaml
+++ b/blueprints/automation/casambi_bt/button_cover_control.yaml
@@ -1,0 +1,178 @@
+blueprint:
+  name: Casambi Button Cover Control
+  description: Control blinds/covers - short press to open/close/stop, hold to open/close continuously
+  domain: automation
+  input:
+    unit_id:
+      name: Unit ID
+      description: The Casambi unit ID of your switch
+      selector:
+        number:
+          mode: box
+    button:
+      name: Button Number
+      description: Button number (0-based)
+      default: 0
+      selector:
+        number:
+          mode: box
+    message_type:
+      name: Message Type (Optional)
+      description: Filter by message type. Leave empty to accept any
+      default: ""
+      selector:
+        text:
+    target_cover:
+      name: Target Cover
+      description: The cover/blind to control
+      selector:
+        entity:
+          domain: cover
+    position_threshold:
+      name: Position Threshold
+      description: Position above which cover will close (below will open)
+      default: 50
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
+    button_state_helper:
+      name: Button State Helper
+      description: Input text helper to track button state (create one per button you want to control)
+      selector:
+        entity:
+          domain: input_text
+
+mode: parallel
+max: 3
+
+variables:
+  message_type: !input message_type
+  target_cover: !input target_cover
+  position_threshold: !input position_threshold
+  button_state_helper: !input button_state_helper
+
+trigger:
+  - platform: event
+    event_type: casambi_bt_switch_event
+    event_data:
+      unit_id: !input unit_id
+      button: !input button
+
+condition:
+  - condition: template
+    value_template: >
+      {% set message_type_filter = message_type | default('') %}
+      {% set event_message_type = trigger.event.data.message_type | string %}
+      {% set event_action = trigger.event.data.action %}
+      {% set message_match = (message_type_filter == '') or (message_type_filter == event_message_type) %}
+      
+      {# Accept all relevant button events #}
+      {{ message_match and event_action in ['button_press', 'button_release', 'button_hold', 'button_release_after_hold'] }}
+
+action:
+  - choose:
+      # Handle short press (button_release without prior hold)
+      - conditions:
+          - condition: template
+            value_template: >
+              {{ trigger.event.data.action == 'button_release' and 
+                 (states(button_state_helper) == 'pressed' or
+                  (states(button_state_helper) != 'holding_open' and 
+                   states(button_state_helper) != 'holding_close')) }}
+        sequence:
+          - choose:
+              # If cover is moving, stop it
+              - conditions:
+                  - condition: template
+                    value_template: >
+                      {{ states(target_cover) in ['opening', 'closing'] }}
+                sequence:
+                  - service: cover.stop_cover
+                    target:
+                      entity_id: !input target_cover
+              # If position > threshold, close
+              - conditions:
+                  - condition: numeric_state
+                    entity_id: !input target_cover
+                    attribute: current_position
+                    above: !input position_threshold
+                sequence:
+                  - service: cover.close_cover
+                    target:
+                      entity_id: !input target_cover
+            # Otherwise open
+            default:
+              - service: cover.open_cover
+                target:
+                  entity_id: !input target_cover
+          # Reset helper after action
+          - service: input_text.set_value
+            target:
+              entity_id: !input button_state_helper
+            data:
+              value: "idle"
+      
+      # Handle button press - just track state
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.action == 'button_press' }}"
+        sequence:
+          - service: input_text.set_value
+            target:
+              entity_id: !input button_state_helper
+            data:
+              value: "pressed"
+      
+      # Handle button release after hold - stop the cover
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.action == 'button_release_after_hold' }}"
+        sequence:
+          - service: cover.stop_cover
+            target:
+              entity_id: !input target_cover
+          - service: input_text.set_value
+            target:
+              entity_id: !input button_state_helper
+            data:
+              value: "released"
+      
+      # Handle button hold - start opening or closing
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.action == 'button_hold' }}"
+        sequence:
+          # Determine direction based on current position
+          - choose:
+              # If position > threshold or cover is closing, open it
+              - conditions:
+                  - condition: or
+                    conditions:
+                      - condition: numeric_state
+                        entity_id: !input target_cover
+                        attribute: current_position
+                        above: !input position_threshold
+                      - condition: state
+                        entity_id: !input target_cover
+                        state: "closing"
+                sequence:
+                  - service: input_text.set_value
+                    target:
+                      entity_id: !input button_state_helper
+                    data:
+                      value: "holding_open"
+                  - service: cover.open_cover
+                    target:
+                      entity_id: !input target_cover
+            # Otherwise close it
+            default:
+              - service: input_text.set_value
+                target:
+                  entity_id: !input button_state_helper
+                data:
+                  value: "holding_close"
+              - service: cover.close_cover
+                target:
+                  entity_id: !input target_cover

--- a/blueprints/automation/casambi_bt/button_short_long_press.yaml
+++ b/blueprints/automation/casambi_bt/button_short_long_press.yaml
@@ -1,0 +1,250 @@
+blueprint:
+  name: Casambi Button Actions
+  description: Versatile button automation with customizable actions for different button events
+  domain: automation
+  input:
+    unit_id:
+      name: Unit ID
+      description: The Casambi unit ID of your switch
+      selector:
+        number:
+          mode: box
+    button:
+      name: Button Number
+      description: Button number (0-based)
+      default: 0
+      selector:
+        number:
+          mode: box
+    message_type:
+      name: Message Type Filter (Optional)
+      description: Filter by message type. Leave empty to accept any
+      default: ""
+      selector:
+        text:
+    
+    # Button Press Action
+    button_press_action:
+      name: Button Press Action (Optional)
+      description: Action when button is initially pressed down
+      default: []
+      selector:
+        action: {}
+    
+    # Short Press Action (Press and Release)
+    short_press_action:
+      name: Short Press Action (Optional)
+      description: Action on quick press and release (< 500ms)
+      default: []
+      selector:
+        action: {}
+    
+    # Long Press Started Action
+    long_press_started_action:
+      name: Long Press Started Action (Optional)
+      description: Action when button hold is detected (after ~500ms)
+      default: []
+      selector:
+        action: {}
+    
+    # Long Press Released Action
+    long_press_released_action:
+      name: Long Press Released Action (Optional)
+      description: Action when button is released after long press
+      default: []
+      selector:
+        action: {}
+    
+    # Continuous Hold Action
+    hold_action:
+      name: Continuous Hold Action (Optional)
+      description: Action to repeat while button is held (requires helper)
+      default: []
+      selector:
+        action: {}
+    
+    # Helper for continuous hold
+    button_state_helper:
+      name: Button State Helper (Optional)
+      description: Input text helper for continuous hold actions. Only needed if using Continuous Hold Action
+      default: ""
+      selector:
+        entity:
+          domain: input_text
+    
+    # Hold repeat interval
+    hold_repeat_interval:
+      name: Hold Repeat Interval
+      description: Milliseconds between continuous hold action repeats
+      default: 200
+      selector:
+        number:
+          min: 50
+          max: 1000
+          step: 50
+          unit_of_measurement: ms
+    
+    # Debounce
+    debounce_time:
+      name: Debounce Time
+      description: Minimum seconds between automation triggers
+      default: 0.5
+      selector:
+        number:
+          min: 0
+          max: 5
+          step: 0.1
+          unit_of_measurement: seconds
+
+mode: parallel
+max: 3
+
+variables:
+  message_type: !input message_type
+  button_state_helper: !input button_state_helper
+  hold_action: !input hold_action
+  hold_repeat_interval: !input hold_repeat_interval
+  debounce_time: !input debounce_time
+
+trigger:
+  - platform: event
+    event_type: casambi_bt_switch_event
+    event_data:
+      unit_id: !input unit_id
+      button: !input button
+
+condition:
+  - condition: template
+    value_template: >
+      {% set message_type_filter = message_type | default('') %}
+      {% set event_message_type = trigger.event.data.message_type | string %}
+      {% set event_action = trigger.event.data.action %}
+      {% set message_match = (message_type_filter == '') or (message_type_filter == event_message_type) %}
+      {% set debounce = debounce_time | default(0.5) %}
+      {% set last_triggered = as_timestamp(state_attr(this.entity_id, 'last_triggered') | default(0)) %}
+      {% set time_passed = as_timestamp(now()) - last_triggered %}
+      
+      {{ message_match and time_passed > debounce }}
+
+action:
+  - choose:
+      # Button Press
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.action == 'button_press' }}"
+        sequence:
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ button_press_action | length > 0 }}"
+                sequence: !input button_press_action
+          # Reset helper if provided
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ button_state_helper != '' }}"
+                sequence:
+                  - service: input_text.set_value
+                    target:
+                      entity_id: !input button_state_helper
+                    data:
+                      value: "pressed"
+      
+      # Short Press (Release)
+      - conditions:
+          - condition: template
+            value_template: >
+              {{ trigger.event.data.action == 'button_release' and
+                 (button_state_helper == '' or 
+                  (states(button_state_helper) != 'holding' and 
+                   states(button_state_helper) != 'continuous_hold')) }}
+        sequence:
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ short_press_action | length > 0 }}"
+                sequence: !input short_press_action
+          # Reset helper
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ button_state_helper != '' }}"
+                sequence:
+                  - service: input_text.set_value
+                    target:
+                      entity_id: !input button_state_helper
+                    data:
+                      value: "idle"
+      
+      # Long Press Started (Hold)
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.action == 'button_hold' }}"
+        sequence:
+          # Update helper
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ button_state_helper != '' }}"
+                sequence:
+                  - service: input_text.set_value
+                    target:
+                      entity_id: !input button_state_helper
+                    data:
+                      value: "holding"
+          
+          # Execute long press started action
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ long_press_started_action | length > 0 }}"
+                sequence: !input long_press_started_action
+          
+          # Start continuous hold if configured
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ hold_action | length > 0 and button_state_helper != '' }}"
+                sequence:
+                  - service: input_text.set_value
+                    target:
+                      entity_id: !input button_state_helper
+                    data:
+                      value: "continuous_hold"
+                  - repeat:
+                      while:
+                        - condition: state
+                          entity_id: !input button_state_helper
+                          state: "continuous_hold"
+                      sequence:
+                        - choose:
+                            - conditions:
+                                - condition: template
+                                  value_template: "{{ hold_action | length > 0 }}"
+                              sequence: !input hold_action
+                        - delay:
+                            milliseconds: !input hold_repeat_interval
+      
+      # Long Press Released
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.action == 'button_release_after_hold' }}"
+        sequence:
+          # Stop continuous hold
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ button_state_helper != '' }}"
+                sequence:
+                  - service: input_text.set_value
+                    target:
+                      entity_id: !input button_state_helper
+                    data:
+                      value: "released"
+          
+          # Execute long press released action
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ long_press_released_action | length > 0 }}"
+                sequence: !input long_press_released_action

--- a/blueprints/automation/casambi_bt/button_toggle_and_dim.yaml
+++ b/blueprints/automation/casambi_bt/button_toggle_and_dim.yaml
@@ -1,0 +1,215 @@
+blueprint:
+  name: Casambi Button Toggle and Dim
+  description: Short press to toggle light, hold to dim (combines toggle and dimming functionality)
+  domain: automation
+  input:
+    unit_id:
+      name: Unit ID
+      description: The Casambi unit ID of your switch
+      selector:
+        number:
+          mode: box
+    button:
+      name: Button Number
+      description: Button number (0-based)
+      default: 0
+      selector:
+        number:
+          mode: box
+    message_type:
+      name: Message Type (Optional)
+      description: Filter by message type. Leave empty to accept any
+      default: ""
+      selector:
+        text:
+    target_light:
+      name: Target Light
+      description: The light to control
+      selector:
+        entity:
+          domain: light
+    dimming_direction:
+      name: Dimming Direction
+      description: Direction to dim when holding the button
+      default: toggle
+      selector:
+        select:
+          options:
+            - label: "Increase Brightness"
+              value: "up"
+            - label: "Decrease Brightness"
+              value: "down"
+            - label: "Toggle Direction (if brightness > 50% dim down, otherwise dim up)"
+              value: "toggle"
+    dimming_step:
+      name: Dimming Step
+      description: How much to change brightness each step (0-255, will be converted to percentage)
+      default: 25
+      selector:
+        number:
+          min: 1
+          max: 50
+          mode: slider
+    dimming_interval:
+      name: Dimming Interval
+      description: Milliseconds between each dimming step
+      default: 200
+      selector:
+        number:
+          min: 50
+          max: 1000
+          step: 50
+          unit_of_measurement: ms
+    button_state_helper:
+      name: Button State Helper
+      description: Input text helper to track button state (create one per button you want to control)
+      selector:
+        entity:
+          domain: input_text
+    debounce_time:
+      name: Debounce Time
+      description: Minimum seconds between toggle actions (prevents accidental double-triggers)
+      default: 1
+      selector:
+        number:
+          min: 0.5
+          max: 5
+          step: 0.5
+          unit_of_measurement: seconds
+
+mode: parallel  # Allow multiple instances
+max: 3
+
+variables:
+  message_type: !input message_type
+  target_light: !input target_light
+  dimming_direction: !input dimming_direction
+  dimming_step: !input dimming_step
+  dimming_interval: !input dimming_interval
+  button_state_helper: !input button_state_helper
+  debounce_time: !input debounce_time
+
+trigger:
+  - platform: event
+    event_type: casambi_bt_switch_event
+    event_data:
+      unit_id: !input unit_id
+      button: !input button
+
+condition:
+  - condition: template
+    value_template: >
+      {% set message_type_filter = message_type | default('') %}
+      {% set event_message_type = trigger.event.data.message_type | string %}
+      {% set event_action = trigger.event.data.action %}
+      {% set message_match = (message_type_filter == '') or (message_type_filter == event_message_type) %}
+      
+      {# Accept all relevant button events #}
+      {{ message_match and event_action in ['button_press', 'button_release', 'button_hold', 'button_release_after_hold'] }}
+
+action:
+  - choose:
+      # Handle short press toggle (button_release without prior hold)
+      - conditions:
+          - condition: template
+            value_template: >
+              {{ trigger.event.data.action == 'button_release' and 
+                 (states(button_state_helper) == 'pressed' or
+                  (states(button_state_helper) != 'holding_up' and 
+                   states(button_state_helper) != 'holding_down')) }}
+        sequence:
+          - service: light.toggle
+            target:
+              entity_id: !input target_light
+          # Reset helper after toggle
+          - service: input_text.set_value
+            target:
+              entity_id: !input button_state_helper
+            data:
+              value: "idle"
+      
+      # Handle button press - just track state
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.action == 'button_press' }}"
+        sequence:
+          - service: input_text.set_value
+            target:
+              entity_id: !input button_state_helper
+            data:
+              value: "pressed"
+      
+      # Handle button release after hold - just update the helper
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.action == 'button_release_after_hold' }}"
+        sequence:
+          - service: input_text.set_value
+            target:
+              entity_id: !input button_state_helper
+            data:
+              value: "released"
+      
+      # Handle button hold - update helper and start dimming loop
+      - conditions:
+          - condition: template
+            value_template: "{{ trigger.event.data.action == 'button_hold' }}"
+        sequence:
+          # Update button state to holding
+          - service: input_text.set_value
+            target:
+              entity_id: !input button_state_helper
+            data:
+              value: "holding"
+          
+          # Determine initial direction and store it
+          - service: input_text.set_value
+            target:
+              entity_id: !input button_state_helper
+            data:
+              value: >
+                {% set light_entity = target_light %}
+                {% set direction = dimming_direction | default('toggle') %}
+                {% if direction == 'down' %}
+                  holding_down
+                {% elif direction == 'up' %}
+                  holding_up
+                {% elif states(light_entity) == 'on' and (state_attr(light_entity, 'brightness') | int(0) > 127) %}
+                  holding_down
+                {% else %}
+                  holding_up
+                {% endif %}
+          
+          # Start dimming loop
+          - repeat:
+              while:
+                - condition: template
+                  value_template: >
+                    {{ states(button_state_helper) in ['holding_up', 'holding_down'] }}
+              sequence:
+                - variables:
+                    light_entity: !input target_light
+                    helper_state: "{{ states(button_state_helper) }}"
+                    dimming_step_value: !input dimming_step
+                    step_pct: "{{ (dimming_step_value | default(25) / 255 * 100) | round(1) }}"
+                    current_brightness: "{{ state_attr(light_entity, 'brightness') | int(255) }}"
+                    calculated_step: >
+                      {% if helper_state == 'holding_down' %}
+                        {% if current_brightness > 16 %}
+                          {{ -step_pct }}
+                        {% else %}
+                          {{ (1 - current_brightness) / 255 * 100 }}
+                        {% endif %}
+                      {% else %}
+                        {{ step_pct }}
+                      {% endif %}
+                
+                - service: light.turn_on
+                  target:
+                    entity_id: !input target_light
+                  data:
+                    brightness_step_pct: "{{ calculated_step }}"
+                    transition: >
+                      {{ (dimming_interval | default(200)) / 1000 }}
+                - delay:
+                    milliseconds: !input dimming_interval

--- a/custom_components/casambi_bt/__init__.py
+++ b/custom_components/casambi_bt/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import Callable, Iterable
 import logging
 from pathlib import Path
+import time
 from typing import Final
 
 from CasambiBt import Casambi, Group, Scene, Unit, UnitControlType
@@ -31,6 +32,80 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Casambi Bluetooth from a config entry."""
     api = CasambiApi(hass, entry, entry.data[CONF_ADDRESS], entry.data[CONF_PASSWORD])
     await api.connect()
+
+    # Event deduplication cache: (unit_id, button, payload_hex) -> timestamp
+    event_cache: dict[tuple[int, int, str], float] = {}
+    DEDUP_WINDOW_SECONDS = 10.0
+
+    _LOGGER.info("Switch event deduplication enabled with %ss window", DEDUP_WINDOW_SECONDS)
+
+    # Register switch event handler that fires Home Assistant events
+    def handle_switch_event(event_data: dict) -> None:
+        """Fire a Home Assistant event when a switch is pressed/released."""
+        # Convert any bytes objects to hex strings for JSON serialization
+        raw_packet = event_data.get("raw_packet")
+        decrypted_data = event_data.get("decrypted_data")
+        payload_hex = event_data.get("payload_hex")
+        extra_data = event_data.get("extra_data")
+
+        # Convert payload_hex to string if it's bytes
+        payload_hex_str = payload_hex.hex() if isinstance(payload_hex, bytes) else payload_hex
+
+        # Check for duplicate events
+        unit_id = event_data.get("unit_id")
+        button = event_data.get("button")
+
+        if unit_id is not None and button is not None and payload_hex_str:
+            cache_key = (unit_id, button, payload_hex_str)
+            current_time = time.time()
+
+            # Clean up old entries from cache
+            for key in list(event_cache.keys()):
+                if current_time - event_cache[key] > DEDUP_WINDOW_SECONDS:
+                    del event_cache[key]
+
+            # Check if this event was seen recently
+            if cache_key in event_cache:
+                _LOGGER.debug(
+                    "Skipping duplicate event: unit=%s, button=%s, payload=%s (last seen %.1fs ago)",
+                    unit_id, button, payload_hex_str[:8],
+                    current_time - event_cache[cache_key]
+                )
+                return
+
+            # Record this event
+            event_cache[cache_key] = current_time
+
+        hass.bus.async_fire(
+            f"{DOMAIN}_switch_event",
+            {
+                "entry_id": entry.entry_id,
+                "unit_id": event_data.get("unit_id"),
+                "button": event_data.get("button"),
+                "action": event_data.get("event"),  # "button_press", "button_hold", "button_release", or "button_release_after_hold"
+                "message_type": event_data.get("message_type"),
+                "flags": event_data.get("flags"),
+                "packet_sequence": event_data.get("packet_sequence"),
+                "raw_packet": raw_packet.hex() if isinstance(raw_packet, bytes) else raw_packet,
+                "decrypted_data": decrypted_data.hex() if isinstance(decrypted_data, bytes) else decrypted_data,
+                "message_position": event_data.get("message_position"),
+                "payload_hex": payload_hex_str,
+                "extra_data": extra_data.hex() if isinstance(extra_data, bytes) else None,
+            }
+        )
+        _LOGGER.debug(
+            "Fired %s_switch_event for unit %s button %s - %s",
+            DOMAIN,
+            event_data.get('unit_id'),
+            event_data.get('button'),
+            event_data.get('event'),
+        )
+
+    # Register the event handler if the library supports it
+    if hasattr(api.casa, 'registerSwitchEventHandler'):
+        api.register_switch_event_callback(handle_switch_event)
+        _LOGGER.info("Switch event handler registered - events will fire as casambi_bt_switch_event")
+
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = api
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -76,6 +151,7 @@ class CasambiApi:
         self.casa: Casambi = Casambi(get_async_client(hass), get_cache_dir(hass))
 
         self._callback_map: dict[int, list[Callable[[Unit], None]]] = {}
+        self._switch_event_callbacks: list[Callable[[dict], None]] = []
         self._cancel_bluetooth_callback: Callable[[], None] | None = None
         self._reconnect_lock = asyncio.Lock()
         self._first_disconnect = True
@@ -99,6 +175,12 @@ class CasambiApi:
 
             self.casa.registerDisconnectCallback(self._casa_disconnect)
             self.casa.registerUnitChangedHandler(self._unit_changed_handler)
+
+            # Register switch event handler if available (new in casambi-bt 0.3.0)
+            if hasattr(self.casa, 'registerSwitchEventHandler'):
+                self.casa.registerSwitchEventHandler(self._switch_event_handler)
+            else:
+                _LOGGER.warning("Switch event handler not available in casambi-bt library. Please update to latest version.")
 
             await self.casa.connect(device, self.password)
             self._first_disconnect = True
@@ -167,6 +249,10 @@ class CasambiApi:
                 _LOGGER.exception("Error during disconnect.")
             self.casa.unregisterUnitChangedHandler(self._unit_changed_handler)
 
+            # Unregister switch event handler if available
+            if hasattr(self.casa, 'unregisterSwitchEventHandler'):
+                self.casa.unregisterSwitchEventHandler(self._switch_event_handler)
+
     @callback
     def _casa_disconnect(self) -> None:
         if self._first_disconnect:
@@ -234,6 +320,29 @@ class CasambiApi:
             return
         for c in self._callback_map[unit.deviceId]:
             c(unit)
+
+    @callback
+    def _switch_event_handler(self, event_data: dict) -> None:
+        """Handle switch events from the Casambi network."""
+        _LOGGER.debug("Switch event received: %s", event_data)
+        for cb in self._switch_event_callbacks:
+            if asyncio.iscoroutinefunction(cb):
+                self.conf_entry.async_create_task(
+                    self.hass, cb(event_data), "switch_event_callback"
+                )
+            else:
+                cb(event_data)
+
+    def register_switch_event_callback(self, callback: Callable[[dict], None]) -> None:
+        """Register a callback for switch events."""
+        self._switch_event_callbacks.append(callback)
+        _LOGGER.debug("Registered switch event callback: %s", callback)
+
+    def unregister_switch_event_callback(self, callback: Callable[[dict], None]) -> None:
+        """Unregister a callback for switch events."""
+        if callback in self._switch_event_callbacks:
+            self._switch_event_callbacks.remove(callback)
+            _LOGGER.debug("Unregistered switch event callback: %s", callback)
 
     @callback
     def _bluetooth_callback(

--- a/custom_components/casambi_bt/__init__.py
+++ b/custom_components/casambi_bt/__init__.py
@@ -37,7 +37,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     event_cache: dict[tuple[int, int, str], float] = {}
     DEDUP_WINDOW_SECONDS = 10.0
 
-    _LOGGER.info("Switch event deduplication enabled with %ss window", DEDUP_WINDOW_SECONDS)
+    _LOGGER.info(
+        "Switch event deduplication enabled with %ss window", DEDUP_WINDOW_SECONDS
+    )
 
     # Register switch event handler that fires Home Assistant events
     def handle_switch_event(event_data: dict) -> None:
@@ -49,7 +51,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         extra_data = event_data.get("extra_data")
 
         # Convert payload_hex to string if it's bytes
-        payload_hex_str = payload_hex.hex() if isinstance(payload_hex, bytes) else payload_hex
+        payload_hex_str = (
+            payload_hex.hex() if isinstance(payload_hex, bytes) else payload_hex
+        )
 
         # Check for duplicate events
         unit_id = event_data.get("unit_id")
@@ -68,8 +72,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if cache_key in event_cache:
                 _LOGGER.debug(
                     "Skipping duplicate event: unit=%s, button=%s, payload=%s (last seen %.1fs ago)",
-                    unit_id, button, payload_hex_str[:8],
-                    current_time - event_cache[cache_key]
+                    unit_id,
+                    button,
+                    payload_hex_str[:8],
+                    current_time - event_cache[cache_key],
                 )
                 return
 
@@ -82,29 +88,41 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 "entry_id": entry.entry_id,
                 "unit_id": event_data.get("unit_id"),
                 "button": event_data.get("button"),
-                "action": event_data.get("event"),  # "button_press", "button_hold", "button_release", or "button_release_after_hold"
+                "action": event_data.get(
+                    "event"
+                ),  # "button_press", "button_hold", "button_release", or "button_release_after_hold"
                 "message_type": event_data.get("message_type"),
                 "flags": event_data.get("flags"),
                 "packet_sequence": event_data.get("packet_sequence"),
-                "raw_packet": raw_packet.hex() if isinstance(raw_packet, bytes) else raw_packet,
-                "decrypted_data": decrypted_data.hex() if isinstance(decrypted_data, bytes) else decrypted_data,
+                "raw_packet": (
+                    raw_packet.hex() if isinstance(raw_packet, bytes) else raw_packet
+                ),
+                "decrypted_data": (
+                    decrypted_data.hex()
+                    if isinstance(decrypted_data, bytes)
+                    else decrypted_data
+                ),
                 "message_position": event_data.get("message_position"),
                 "payload_hex": payload_hex_str,
-                "extra_data": extra_data.hex() if isinstance(extra_data, bytes) else None,
-            }
+                "extra_data": (
+                    extra_data.hex() if isinstance(extra_data, bytes) else None
+                ),
+            },
         )
         _LOGGER.debug(
             "Fired %s_switch_event for unit %s button %s - %s",
             DOMAIN,
-            event_data.get('unit_id'),
-            event_data.get('button'),
-            event_data.get('event'),
+            event_data.get("unit_id"),
+            event_data.get("button"),
+            event_data.get("event"),
         )
 
     # Register the event handler if the library supports it
-    if hasattr(api.casa, 'registerSwitchEventHandler'):
+    if hasattr(api.casa, "registerSwitchEventHandler"):
         api.register_switch_event_callback(handle_switch_event)
-        _LOGGER.info("Switch event handler registered - events will fire as casambi_bt_switch_event")
+        _LOGGER.info(
+            "Switch event handler registered - events will fire as casambi_bt_switch_event"
+        )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = api
 
@@ -177,10 +195,12 @@ class CasambiApi:
             self.casa.registerUnitChangedHandler(self._unit_changed_handler)
 
             # Register switch event handler if available (new in casambi-bt 0.3.0)
-            if hasattr(self.casa, 'registerSwitchEventHandler'):
+            if hasattr(self.casa, "registerSwitchEventHandler"):
                 self.casa.registerSwitchEventHandler(self._switch_event_handler)
             else:
-                _LOGGER.warning("Switch event handler not available in casambi-bt library. Please update to latest version.")
+                _LOGGER.warning(
+                    "Switch event handler not available in casambi-bt library. Please update to latest version."
+                )
 
             await self.casa.connect(device, self.password)
             self._first_disconnect = True
@@ -250,7 +270,7 @@ class CasambiApi:
             self.casa.unregisterUnitChangedHandler(self._unit_changed_handler)
 
             # Unregister switch event handler if available
-            if hasattr(self.casa, 'unregisterSwitchEventHandler'):
+            if hasattr(self.casa, "unregisterSwitchEventHandler"):
                 self.casa.unregisterSwitchEventHandler(self._switch_event_handler)
 
     @callback
@@ -338,7 +358,9 @@ class CasambiApi:
         self._switch_event_callbacks.append(callback)
         _LOGGER.debug("Registered switch event callback: %s", callback)
 
-    def unregister_switch_event_callback(self, callback: Callable[[dict], None]) -> None:
+    def unregister_switch_event_callback(
+        self, callback: Callable[[dict], None]
+    ) -> None:
         """Unregister a callback for switch events."""
         if callback in self._switch_event_callbacks:
             self._switch_event_callbacks.remove(callback)

--- a/custom_components/casambi_bt/number.py
+++ b/custom_components/casambi_bt/number.py
@@ -67,7 +67,8 @@ class CasambiVerticalNumber(CasambiEntity, NumberEntity, metaclass=ABCMeta):
     """
 
     def __init__(
-        self, api: CasambiApi,
+        self,
+        api: CasambiApi,
         description: TypedNumberEntityDescription,
         obj: Group | Unit,
     ) -> None:
@@ -123,7 +124,8 @@ class CasambiVerticalNumberGroup(CasambiVerticalNumber, CasambiNetworkGroup):
         """Get the average vertical value of the group."""
         group = cast("Group", self._obj)
         values = [
-            float(unit.state.vertical) for unit in group.units
+            float(unit.state.vertical)
+            for unit in group.units
             if unit.state is not None and unit.state.vertical is not None
         ]
         if values:

--- a/docs/BLUEPRINTS.md
+++ b/docs/BLUEPRINTS.md
@@ -1,0 +1,51 @@
+# Automation Blueprints
+
+This integration includes ready-to-use blueprints for common switch automation patterns.
+
+## Available Blueprints
+
+### Toggle and Dim
+**File:** `blueprints/automation/casambi_bt/button_toggle_and_dim.yaml`
+
+All-in-one light control:
+- Short press: Toggle light on/off
+- Hold: Dim light up/down (alternates direction)
+
+### Button Short/Long Press
+**File:** `blueprints/automation/casambi_bt/button_short_long_press.yaml`
+
+Versatile automation for any button event:
+- Configure different actions for short press and long press
+- Can control any entity or service
+
+### Cover Control
+**File:** `blueprints/automation/casambi_bt/button_cover_control.yaml`
+
+Smart blind/cover control:
+- Press: Open/close/stop (cycles through states)
+- Hold: Continuous movement
+
+## How to Use Blueprints
+
+1. Copy the blueprint files to your Home Assistant `blueprints/automation/` directory
+2. Go to Settings → Automations & Scenes → Blueprints
+3. Find the blueprint and click "Create Automation"
+4. Fill in the required fields:
+   - Switch Unit ID
+   - Button Number
+   - Target entity/entities
+5. Save the automation
+
+## Finding Your Switch Details
+
+To use these blueprints, you need:
+- **Unit ID**: The ID of your switch (see [Switch Event Documentation](SWITCH_EVENTS.md))
+- **Button Number**: 0-3 for 4-button switches (0 is typically the top button)
+
+## Example Configuration
+
+For a "Toggle and Dim" automation:
+- Name: `Living Room Switch`
+- Switch Unit ID: `42`
+- Button Number: `0`
+- Target Light: `light.living_room`

--- a/docs/SWITCH_EVENTS.md
+++ b/docs/SWITCH_EVENTS.md
@@ -1,0 +1,98 @@
+# Switch Event Documentation
+
+This integration fires Home Assistant events when Casambi switches are pressed. These events can be used to trigger automations.
+
+## Event Details
+
+**Event Type:** `casambi_bt_switch_event`
+
+**Event Data:**
+- `unit_id` - The ID of the switch unit
+- `button` - Button number (0-3 for 4-button switches)
+- `action` - The type of button action:
+  - `button_press` - Button initially pressed
+  - `button_hold` - Button held down (~500ms after press)
+  - `button_release` - Button released after short press
+  - `button_release_after_hold` - Button released after hold
+
+## Finding Your Switch Unit ID
+
+1. Enable debug logging in `configuration.yaml`:
+   ```yaml
+   logger:
+     default: info
+     logs:
+       custom_components.casambi_bt: debug
+   ```
+
+2. Press a button on your switch
+3. Check the logs for entries like:
+   ```
+   Fired casambi_bt_switch_event for unit 42 button 0 - button_press
+   ```
+   The unit ID in this example is `42`
+
+## Example Automations
+
+### Simple Light Toggle
+```yaml
+automation:
+  - alias: "Kitchen Light Toggle"
+    trigger:
+      - platform: event
+        event_type: casambi_bt_switch_event
+        event_data:
+          unit_id: 42
+          button: 0
+          action: button_press
+    action:
+      - service: light.toggle
+        target:
+          entity_id: light.kitchen
+```
+
+### Different Actions for Short/Long Press
+```yaml
+automation:
+  - alias: "Living Room - Short Press"
+    trigger:
+      - platform: event
+        event_type: casambi_bt_switch_event
+        event_data:
+          unit_id: 42
+          button: 0
+          action: button_release  # Short press
+    action:
+      - service: light.toggle
+        target:
+          entity_id: light.living_room
+  
+  - alias: "Living Room - Long Press"
+    trigger:
+      - platform: event
+        event_type: casambi_bt_switch_event
+        event_data:
+          unit_id: 42
+          button: 0
+          action: button_hold
+    action:
+      - service: light.turn_on
+        target:
+          entity_id: light.living_room
+        data:
+          brightness_pct: 100
+```
+
+## Using Developer Tools
+
+You can monitor switch events in real-time:
+1. Go to Developer Tools → Events
+2. Under "Listen to events", enter: `casambi_bt_switch_event`
+3. Click "Start Listening"
+4. Press buttons on your switch to see the events
+
+## Notes
+
+- Switches do not appear as entities in Home Assistant
+- The integration automatically filters duplicate events
+- Some wireless switches may occasionally generate extra events, but this doesn't affect functionality


### PR DESCRIPTION
## Summary

  This PR adds support for Casambi switch button events in Home Assistant. Physical switches now fire `casambi_bt_switch_event` events that can be used in automations. Note that switches do not appear as entities - they only fire events.

  ## Changes

  - Added switch event handler registration when the casambi-bt library supports it (graceful fallback for older versions)
  - Switch events are fired as `casambi_bt_switch_event` with event data including:
    - `unit_id` - The switch unit ID
    - `button` - Button number (0-3 for 4-button switches)
    - `action` - Event type: `button_press`, `button_hold`, `button_release`, or `button_release_after_hold`
    - Additional debugging information (packet data, sequence numbers)
  - Implemented event deduplication with 10-second window to filter duplicate BLE packets
  - Added switch event documentation (`docs/SWITCH_EVENTS.md`)
  - Included automation blueprints for common use cases
  - Updated README with switch event information

  ## Requirements

  Requires casambi-bt library with switch event support (will be available after merging lkempf/casambi-bt#37).

  ## Testing

  Tested with the following devices:
  - LD220WCM
  - SC-TI-CA
  - 4CHANNEL_SW EVO (will generate extra unknown events)

  Various automation scenarios tested including toggle lights, dim on hold, and cover control.

  ## Documentation & Blueprints

  The PR includes:
  - **Switch Event Documentation** (`docs/SWITCH_EVENTS.md`) - How to find unit IDs, example automations
  - **Blueprint Documentation** (`docs/BLUEPRINTS.md`) - How to use the included blueprints
  - **Automation Blueprints**:
    - `button_toggle_and_dim.yaml` - All-in-one light control
    - `button_short_long_press.yaml` - Versatile button actions
    - `button_cover_control.yaml` - Smart blind/cover control

  ## Example Automation

  ```yaml
  automation:
    - alias: "Living Room Switch"
      trigger:
        - platform: event
          event_type: casambi_bt_switch_event
          event_data:
            unit_id: 42
            button: 0
            action: button_press
      action:
        - service: light.toggle
          target:
            entity_id: light.living_room
  ```

  Notes

  - Switches do not appear as entities in Home Assistant - they only fire events
  - The integration handles event deduplication automatically
  - Some switches may generate extra events, but this doesn't affect functionality
  - Debug logging available for troubleshooting switch detection