### PR TITLE
Use passive Bluetooth scanning for reconnect detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,34 @@ Not supported yet:
 - Switches
 - Sensors
 
+## Linux / BlueZ passive scanning
+
+When using a local Bluetooth adapter on Linux, passive scanning requires
+BlueZ to expose the `org.bluez.AdvertisementMonitorManager1` D-Bus interface.
+
+BlueZ currently marks this interface as experimental. On distributions where
+experimental D-Bus interfaces are disabled, Home Assistant may therefore
+detect the adapter as not supporting passive scanning and fall back to active
+scanning.
+
+If passive scanning is not available, enable the BlueZ experimental D-Bus
+interfaces in `/etc/bluetooth/main.conf`:
+
+```ini
+[General]
+Experimental = true
+```
+
+Then restart BlueZ and Home Assistant.
+
+The interface can be checked with:
+
+```
+busctl introspect org.bluez /org/bluez/hci0 | grep AdvertisementMonitorManager
+```
+
+KernelExperimental does not need to be enabled for this.
+
 ## Reporting issues
 
 Before reporting issues make sure that you have the debug log enabled for all relevant components. This can be done by placing the following in `configuration.yaml` of your HA installation:

--- a/custom_components/casambi_bt/__init__.py
+++ b/custom_components/casambi_bt/__init__.py
@@ -96,7 +96,7 @@ class CasambiApi:
             self.hass,
             self._bluetooth_callback,
             {"address": self.address, "connectable": True},
-            bluetooth.BluetoothScanningMode.ACTIVE,
+            bluetooth.BluetoothScanningMode.PASSIVE,
         )
 
     async def connect(self) -> None:


### PR DESCRIPTION
Related to #154.

The integration currently registers its address-specific Bluetooth callback
using `BluetoothScanningMode.ACTIVE`.

The callback is only used to detect advertisements while the Casambi
connection is down and schedule the existing reconnect task. It does not
require active scan-response data.

Using ACTIVE here unnecessarily registers the Casambi address for active
scanning. Home Assistant may consequently schedule recurring active scan
windows even while the Casambi GATT connection is healthy.

This changes the callback to `BluetoothScanningMode.PASSIVE`.

### Linux / BlueZ passive scanning

While investigating #154 with a local Linux Bluetooth adapter, I found that
Home Assistant can only use BlueZ passive advertisement monitoring when BlueZ
exposes the `org.bluez.AdvertisementMonitorManager1` D-Bus interface.

BlueZ currently exposes this interface as experimental. If experimental D-Bus
interfaces are disabled, Home Assistant can detect the adapter as not
supporting passive scanning and fall back to active scanning.

The README now documents how to enable this on Linux:

    [General]
    Experimental = true

in `/etc/bluetooth/main.conf`, followed by restarting BlueZ and Home Assistant.

It also documents how to verify support with:

    busctl introspect org.bluez /org/bluez/hci0 | grep AdvertisementMonitorManager

`KernelExperimental` is not required for this.

### Observed behaviour

With the ACTIVE callback, periodic active scan windows caused large bursts of
BlueZ device/cache activity on a local adapter.

After enabling BlueZ advertisement monitoring support and registering the
Casambi callback as PASSIVE, normal operation remains passive and those
periodic active scan bursts disappear.

Connection recovery itself remains handled by the existing reconnect logic.

This is intentionally separate from the connection-recovery changes in
lkempf/casambi-bt#73.