### PR TITLE
Fix reauth never completing

### DIFF
--- a/custom_components/casambi_bt/config_flow.py
+++ b/custom_components/casambi_bt/config_flow.py
@@ -193,7 +193,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
 
             try:
-                await _validate_input(self.hass, user_input)
+                await _validate_input(self.hass, data)
             except NetworkNotFoundError:
                 errors["base"] = "cannot_connect"
             except AuthenticationError:


### PR DESCRIPTION
_validate_input reads both CONF_ADDRESS and CONF_PASSWORD, but async_step_reauth_confirm passed it user_input, which only carries the password because that is all REAUTH_SCHEMA collects. The lookup raised KeyError: 'address', the broad except turned it into errors["base"] = "unknown", and the form came back with a generic error. Reauth could never succeed.

The merged dict is already built on the line above for the entry update, so pass that instead.