### PR TITLE
Fix invalid color modes on mixed light groups

### DIFF
--- a/custom_components/casambi_bt/light.py
+++ b/custom_components/casambi_bt/light.py
@@ -237,8 +237,18 @@ class CasambiLightGroup(CasambiLight, CasambiNetworkGroup):
         for unit in group.units:
             supported_modes = supported_modes.union(self._capabilities_helper(unit))
 
+        # ONOFF, BRIGHTNESS and UNKNOWN stand for "nothing better known".
+        # Home Assistant rejects them next to a real color mode, which is what
+        # a group mixing e.g. a plain dimmer and an RGB luminaire produces, so
+        # keep only the modes the group can actually use.
+        supported_modes.discard(ColorMode.UNKNOWN)
+        if len(supported_modes) > 1:
+            supported_modes.discard(ColorMode.ONOFF)
+        if len(supported_modes) > 1:
+            supported_modes.discard(ColorMode.BRIGHTNESS)
+
         if len(supported_modes) == 0:
-            supported_modes.add(ColorMode.UNKNOWN)
+            supported_modes.add(ColorMode.ONOFF)
         self._attr_supported_color_modes = supported_modes
 
         desc = TypedEntityDescription(


### PR DESCRIPTION
CasambiLightGroup unions _capabilities_helper over every unit in the group. That helper returns ONOFF, BRIGHTNESS or UNKNOWN as a placeholder when it finds nothing better, so a group mixing a plain dimmer with an RGB luminaire ends up advertising {BRIGHTNESS, RGB}. Home Assistant's valid_supported_color_modes rejects BRIGHTNESS or ONOFF alongside any other mode, and rejects UNKNOWN outright, so such a group logs

  sets invalid supported color modes {<ColorMode.BRIGHTNESS>,
  <ColorMode.RGB>}, this will stop working in Home Assistant Core 2025.3

The empty-group fallback has the same problem: UNKNOWN on its own is not a mode Home Assistant accepts either.

Drop the placeholders once a real mode is present, and fall back to ONOFF rather than UNKNOWN when a group has no light capability at all turnOn/turnOff work on any group, so that claim is accurate. A group of plain dimmers still reports BRIGHTNESS, unchanged.

| Case | Before | After |
|---|---|---|
| Group: dimmer + RGB | ✗ `Invalid supported_color_modes [BRIGHTNESS, RGB]` | ✓ `{rgb}` |
| Group: dimmers only | ✓ `{brightness}` | ✓ `{brightness}` (no regression) |
| Group: no light controls | ✗ `Invalid supported_color_modes [UNKNOWN]` | ✓ accepted |